### PR TITLE
Fix issue notified of by Tobin in PR #9

### DIFF
--- a/build
+++ b/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! BINOC_CMAKE_PATH="$(which cmake 2>/dev/null)" && uname | grep -i 'msys|mingw'; then
+if ! BINOC_CMAKE_PATH="$(which cmake 2>/dev/null)" && uname | grep -Ei 'msys|mingw'; then
 	if [ -f "/c/Program Files/CMake/bin/cmake.exe" ]; then
 		BINOC_CMAKE_PATH="/c/Program Files/CMake/bin/cmake.exe"
 	elif [ -f "/c/Program Files (x86)/CMake/bin/cmake.exe" ]; then


### PR DESCRIPTION
> the grep command you used did not work with the mozilla-build version of MSYS

I overlooked the fact that it's a regexp, it should be fixed now with this PR.